### PR TITLE
NeDB findOneAndUpdate(): Add 'manual' option to allow field modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Once a document is saved, it will automatically be assigned a unique identifier 
 
 If you specified a default value (or function) for a schema variable, that value will be assigned on creation of the object.
 
-An alternative to `.save()` is `.findOneAndUpdate(query, update, options)`. This static method will find and update (or insert) a document in one atomic operation (atomicity is guaranteed in MongoDB only). Using the `{upsert: true}` option will return a new document if one is not found with the given query.
+An alternative to `.save()` is `.findOneAndUpdate(query, update, options)`. This static method will find and update (or insert) a document in one atomic operation (atomicity is guaranteed in MongoDB only). Using the `{upsert: true}` option will return a new document if one is not found with the given query. For NeDB, you can use the option `{manual: true}` to specify field modifiers manually (see NeDB [docs](https://github.com/seald/nedb#updating-documents) for a complete list).
 
 ### Loading
 

--- a/lib/clients/nedbclient.js
+++ b/lib/clients/nedbclient.js
@@ -468,7 +468,7 @@ class NeDbClient extends DatabaseClient {
    * @return {boolean}
    */
   isNativeId(value) {
-    return String(value).match(/^[a-zA-Z0-9]{16}$/) !== null;
+    return String(value).match(/^[a-zA-Z0-9-]{16}$/) !== null;
   }
 
   /**

--- a/lib/clients/nedbclient.js
+++ b/lib/clients/nedbclient.js
@@ -468,7 +468,7 @@ class NeDbClient extends DatabaseClient {
    * @return {boolean}
    */
   isNativeId(value) {
-    return String(value).match(/^[a-zA-Z0-9-]{16}$/) !== null;
+    return String(value).match(/^[a-zA-Z0-9-]*$/) !== null;
   }
 
   /**

--- a/lib/clients/nedbclient.js
+++ b/lib/clients/nedbclient.js
@@ -237,7 +237,7 @@ class NeDbClient extends DatabaseClient {
             return resolve(null);
           }
         } else {
-          return db.update(query, { $set: values }, function(error, result) {
+          return db.update(query, options.manual ? values : { $set: values }, function(error, result) {
             if (error) return reject(error);
 
             // Fixes issue #55. Remove when NeDB is updated to v1.8+


### PR DESCRIPTION
Marpat uses the modifier `{ $set: { values } }` by default, making impossible the use of NeDB update field modifiers, most notably `$unset`.

The use of `{ manual: true }` as an option allows to specify these.